### PR TITLE
Add support for injecting integrations

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": ["playground", "theme-playground", "theme-ssg", "test-e2e-ssg"]
+	"ignore": ["docs", "playground", "theme-playground", "theme-ssg", "test-e2e-ssg"]
 }

--- a/.changeset/olive-crabs-boil.md
+++ b/.changeset/olive-crabs-boil.md
@@ -1,0 +1,24 @@
+---
+"astro-theme-provider": minor
+---
+
+Add support for adding integrations to a theme
+
+```ts
+integrations: [
+  // Add integrations
+  inoxsitemap(),
+  // Check for other integrations
+  ({ integrations }) => {
+    if (!integrations.contains('@astrojs/sitemap')) {
+      return inoxsitemap()
+    }
+  },
+  // Pass user options to integrations
+  ({ config }) => {
+    if (config.sitemap) {
+      return inoxsitemap(config.sitemap)
+    }
+  },
+]
+```

--- a/docs/src/content/docs/reference/author.mdx
+++ b/docs/src/content/docs/reference/author.mdx
@@ -92,6 +92,41 @@ Directory that contains all of the pages for a theme
 
 Directory that contains a theme's static assets (`favicon.svg`, etc). By default, these assets act as placeholders and can be overwritten by assets located in a user's `public` real folder.
 
+### `integrations`
+
+**Type**: `Array<AstroIntegration | (options: { config: z.infer<Schema>, integrations: string[] }) => AstroIntegration | false | null | undefined>`
+
+An array of integrations that will be included with the theme
+
+```ts
+integrations: [
+  mdx(),
+  sitemap(),
+]
+```
+
+```ts
+integrations: [
+  // Check for other integrations
+  ({ integrations }) => {
+    if (!integrations.contains('@astrojs/sitemap')) {
+      return inoxsitemap()
+    }
+  },
+]
+```
+
+```ts
+integrations: [
+  // Pass user options to integrations
+  ({ config }) => {
+    if (config.sitemap) {
+      return inoxsitemap(config.sitemap)
+    }
+  },
+]
+```
+
 ### `imports`
 
 **Type**: `Record<string, Record<string, string> | string[] | string | false>`

--- a/package/package.json
+++ b/package/package.json
@@ -2,11 +2,7 @@
 	"name": "astro-theme-provider",
 	"version": "0.2.0",
 	"description": "Easily create theme integrations for Astro",
-	"keywords": [
-		"astro",
-		"withastro",
-		"astro-integration"
-	],
+	"keywords": ["astro", "withastro", "astro-integration"],
 	"author": "Bryce Russell",
 	"license": "Unlicense",
 	"repository": {
@@ -28,9 +24,7 @@
 			"default": "./dist/index.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"peerDependencies": {
 		"@astrojs/db": ">=0.8.0",
 		"astro": ">=3"

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -188,7 +188,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 						let integration: ReturnType<Extract<typeof option, (...args: any[]) => any>>
 						if (typeof option === "function") {
 							const names = config.integrations.map(i => i.name)
-							integration = option({ userConfig: userConfig, integrations: names })
+							integration = option({ config: userConfig, integrations: names })
 						} else {
 							integration = option
 						}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -52,7 +52,9 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 			layouts: `layouts/${GLOB_ASTRO}`,
 			components: `components/${GLOB_COMPONENTS}`,
 		},
-		integrations: []
+		integrations: [
+			() => staticDir(authorOptions.publicDir)
+		]
 	};
 
 	if (typeof authorOptions.pageDir === "string") {
@@ -181,10 +183,6 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 					// HMR for theme author's package
 					watchDirectory(params, themeRoot);
 
-					// Add `astro-public` integration to handle `/public` folder logic
-					addIntegration(params, {
-						integration: staticDir(authorOptions.publicDir!),
-					});
 					// Add integrations from author (like mdx or sitemap)
 					for (const option of authorOptions.integrations) {
 						let integration: ReturnType<Extract<typeof option, (...args: any[]) => any>>

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -52,9 +52,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 			layouts: `layouts/${GLOB_ASTRO}`,
 			components: `components/${GLOB_COMPONENTS}`,
 		},
-		integrations: [
-			() => staticDir(authorOptions.publicDir)
-		]
+		integrations: [() => staticDir(authorOptions.publicDir)],
 	};
 
 	if (typeof authorOptions.pageDir === "string") {
@@ -185,15 +183,15 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 					// Add integrations from author (like mdx or sitemap)
 					for (const option of authorOptions.integrations) {
-						let integration: ReturnType<Extract<typeof option, (...args: any[]) => any>>
+						let integration: ReturnType<Extract<typeof option, (...args: any[]) => any>>;
 						if (typeof option === "function") {
-							const names = config.integrations.map(i => i.name)
-							integration = option({ config: userConfig, integrations: names })
+							const names = config.integrations.map((i) => i.name);
+							integration = option({ config: userConfig, integrations: names });
 						} else {
-							integration = option
+							integration = option;
 						}
-						if (!integration) continue
-						addIntegration(params, { integration })
+						if (!integration) continue;
+						addIntegration(params, { integration });
 					}
 
 					// Dynamically create virtual modules using globs, imports, or exports

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -52,6 +52,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 			layouts: `layouts/${GLOB_ASTRO}`,
 			components: `components/${GLOB_COMPONENTS}`,
 		},
+		integrations: []
 	};
 
 	if (typeof authorOptions.pageDir === "string") {
@@ -184,6 +185,18 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 					addIntegration(params, {
 						integration: staticDir(authorOptions.publicDir!),
 					});
+					// Add integrations from author (like mdx or sitemap)
+					for (const option of authorOptions.integrations) {
+						let integration: ReturnType<Extract<typeof option, (...args: any[]) => any>>
+						if (typeof option === "function") {
+							const names = config.integrations.map(i => i.name)
+							integration = option({ userConfig: userConfig, integrations: names })
+						} else {
+							integration = option
+						}
+						if (!integration) continue
+						addIntegration(params, { integration })
+					}
 
 					// Dynamically create virtual modules using globs, imports, or exports
 					for (let [name, option] of Object.entries(authorOptions.imports)) {

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -34,7 +34,7 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 	log?: "verbose" | "minimal" | boolean;
 	schema?: Schema;
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
-	integrations?: Array<AstroIntegration | ((options: { userConfig: z.infer<Schema>, integrations: string[] }) => AstroIntegration | false | null | undefined)>
+	integrations?: Array<AstroIntegration | ((options: { config: z.infer<Schema>, integrations: string[] }) => AstroIntegration | false | null | undefined)>
 }>;
 
 export type UserOptions<ThemeName extends string, Schema extends z.ZodTypeAny = z.ZodTypeAny> = {

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -1,8 +1,8 @@
+import type { AstroIntegration } from "astro";
 import type { Option as PageDirOption } from "astro-pages";
 import type { Option as StaticDirOption } from "astro-public/types";
 import type { z } from "astro/zod";
 import type { ModuleExports, ModuleImports, ModuleObject } from "../utils/virtual.js";
-import type { AstroIntegration } from "astro";
 
 export type ValueOrArray<T> = T | ValueOrArray<T>[];
 
@@ -34,7 +34,10 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 	log?: "verbose" | "minimal" | boolean;
 	schema?: Schema;
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
-	integrations?: Array<AstroIntegration | ((options: { config: z.infer<Schema>, integrations: string[] }) => AstroIntegration | false | null | undefined)>
+	integrations?: Array<
+		| AstroIntegration
+		| ((options: { config: z.infer<Schema>; integrations: string[] }) => AstroIntegration | false | null | undefined)
+	>;
 }>;
 
 export type UserOptions<ThemeName extends string, Schema extends z.ZodTypeAny = z.ZodTypeAny> = {

--- a/package/src/internal/types.ts
+++ b/package/src/internal/types.ts
@@ -2,6 +2,7 @@ import type { Option as PageDirOption } from "astro-pages";
 import type { Option as StaticDirOption } from "astro-public/types";
 import type { z } from "astro/zod";
 import type { ModuleExports, ModuleImports, ModuleObject } from "../utils/virtual.js";
+import type { AstroIntegration } from "astro";
 
 export type ValueOrArray<T> = T | ValueOrArray<T>[];
 
@@ -33,6 +34,7 @@ export type AuthorOptions<ThemeName extends string, Schema extends z.ZodTypeAny>
 	log?: "verbose" | "minimal" | boolean;
 	schema?: Schema;
 	imports?: Record<string, string | ModuleImports | ModuleExports | ModuleObject>;
+	integrations?: Array<AstroIntegration | ((options: { userConfig: z.infer<Schema>, integrations: string[] }) => AstroIntegration | false | null | undefined)>
 }>;
 
 export type UserOptions<ThemeName extends string, Schema extends z.ZodTypeAny = z.ZodTypeAny> = {

--- a/package/tests/theme.test.js
+++ b/package/tests/theme.test.js
@@ -16,7 +16,7 @@ const packagePages = resolve(packageSrc, "pages");
 const packageEntrypoint = resolve(packageRoot, "index.ts");
 const packageJSON = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf-8"));
 const packageName = packageJSON.name;
-const astroIntegration = { name: 'astro-integration' }
+const astroIntegration = { name: "astro-integration" };
 const defaultModules = {
 	[`${packageName}/config`]: {},
 	[`${packageName}/css`]: ["css/styles.css"],
@@ -51,9 +51,7 @@ const astroConfigSetupParamsStub = (params) => ({
 	config: {
 		root: pathToFileURL(`${projectRoot}/`),
 		srcDir: pathToFileURL(`${projectSrc}/`),
-		integrations: [
-			astroIntegration,
-		]
+		integrations: [astroIntegration],
 	},
 	...(params || {}),
 });
@@ -127,12 +125,14 @@ describe("defineTheme", () => {
 			});
 
 			it("should inject integrations", () => {
-				const theme = defineTheme({ integrations: [ astroIntegration ] })();
+				const theme = defineTheme({ integrations: [astroIntegration] })();
 				const params = astroConfigSetupParamsStub();
 
 				theme.hooks["astro:config:setup"]?.(params);
 
-				const call = params.updateConfig.mock.calls.find(call => call.arguments[0]?.integrations?.[0].name === astroIntegration.name);
+				const call = params.updateConfig.mock.calls.find(
+					(call) => call.arguments[0]?.integrations?.[0].name === astroIntegration.name,
+				);
 
 				for (const moduleName of Object.keys(defaultModules)) {
 					assert.equal(call.arguments[0].integrations[0], astroIntegration);
@@ -140,22 +140,24 @@ describe("defineTheme", () => {
 			});
 
 			it("should inject integrations with user config", () => {
-				const theme = defineTheme({ 
-					schema: z.object({ a: z.literal('do-not-add').nullish() }),
-					integrations: [ 
+				const theme = defineTheme({
+					schema: z.object({ a: z.literal("do-not-add").nullish() }),
+					integrations: [
 						({ config }) => {
-							if (!config.a) return astroIntegration
-						} 
-					]
-				})({ 
-					config: { a: 'do-not-add' }
+							if (!config.a) return astroIntegration;
+						},
+					],
+				})({
+					config: { a: "do-not-add" },
 				});
 
 				const params = astroConfigSetupParamsStub();
 
 				theme.hooks["astro:config:setup"]?.(params);
 
-				const called = params.updateConfig.mock.calls.some(call => call.arguments[0]?.integrations?.[0].name === astroIntegration.name);
+				const called = params.updateConfig.mock.calls.some(
+					(call) => call.arguments[0]?.integrations?.[0].name === astroIntegration.name,
+				);
 
 				for (const moduleName of Object.keys(defaultModules)) {
 					assert.equal(called, false);

--- a/tests/themes/theme-playground/package.json
+++ b/tests/themes/theme-playground/package.json
@@ -9,9 +9,7 @@
 		"url": "https://github.com/UserName/theme-playground",
 		"directory": "package"
 	},
-	"keywords": [
-		"astro-integration"
-	],
+	"keywords": ["astro-integration"],
 	"scripts": {},
 	"devDependencies": {
 		"@types/node": "^20.12.7",

--- a/tests/themes/theme-ssg/package.json
+++ b/tests/themes/theme-ssg/package.json
@@ -9,9 +9,7 @@
 		"url": "https://github.com/UserName/theme-ssg",
 		"directory": "package"
 	},
-	"keywords": [
-		"astro-integration"
-	],
+	"keywords": ["astro-integration"],
 	"scripts": {},
 	"devDependencies": {
 		"@types/node": "^20.12.7",


### PR DESCRIPTION
**Closes**: https://github.com/astrolicious/astro-theme-provider/issues/22

This PR allows themes to add other integrations alongside the theme. This is useful for adding integrations like mdx or sitemap to make themes more feature complete.

## Todo

- [x] Add docs
- [x] Tests

## Examples

**Add integrations**:
```ts
defineTheme({
	name: 'my-theme',
	integrations: [
		mdx(),
		sitemap()
	]
})
```

**Use user validated config to configure integrations**:
```ts
defineTheme({
	name: 'my-theme',
	schema: z.object({
		sitemap: z.boolean()
	}),
	integrations: [
		({ config }) => {
			if (config.sitemap) return sitemap()
		}
	]
})
```

**Check for other integrations**:
```ts
defineTheme({
	name: 'my-theme',
	integrations: [
		({ integrations }) => {
			if (!integrations.contains('@astrojs/sitemap'))
				return inoxsitemap()
		}
	]
})
```
