### PR TITLE
add baseline editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# Set default charset
+charset = utf-8
+# Unix-style newlines
+end_of_line = lf
+# No automatic newline endings
+insert_final_newline = false
+# 2 character-sized tab indentation
+indent_size = 2
+indent_style = tab
+# remove whitespace before newlines
+trim_trailing_whitespace = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,19 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      contents: write
       pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+      deployments: read
+      id-token: read
+      discussions: read
+      packages: read
+      pages: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Addresses https://github.com/astrolicious/astro-theme-provider/issues/87 though potentially incompletely. Note that I tried to stay as close to the [Biome defaults](https://biomejs.dev/formatter/#options). One unspecified setting was `insert_final_newline`, which I usually enable, but disabled here.

Additionally, it may make sense to add extra configuration patterns for things like markdown files to avoid unintended `trim_trailing_whitespace`.