### PR TITLE
Rename virtual modules to use a colon : as a separator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,19 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      contents: write
       pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+      checks: read
+      deployments: read
+      discussions: read
+      packages: read
+      pages: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/docs/src/content/docs/authoring-a-theme/index.mdx
+++ b/docs/src/content/docs/authoring-a-theme/index.mdx
@@ -14,7 +14,7 @@ By default, any Layouts inside the `layouts` folder at the root of your package 
 
 ```ts
 ---
-import { Layout } from 'my-theme/layout';
+import { Layout } from 'my-theme:layout';
 ---
 ```
 
@@ -24,7 +24,7 @@ By default, any Components inside the `components` folder at the root of your pa
 
 ```ts
 ---
-import { Heading } from 'my-theme/components';
+import { Heading } from 'my-theme:components';
 ---
 ```
 
@@ -34,7 +34,7 @@ By default, any Styles inside the `css` folder at the root of your package will 
 
 ```ts
 ---
-import 'my-theme/css'
+import 'my-theme:css'
 ---
 ```
 
@@ -44,7 +44,7 @@ By default, any Images inside the `assets` folder at the root of your package wi
 
 ```ts
 ---
-import { logo } from 'my-theme/layout';
+import { logo } from 'my-theme:layout';
 ---
 ```
 
@@ -129,7 +129,7 @@ export default defineTheme({
 ```astro
 ---
 // Includes styles from css files
-import { Heading, logo } from 'my-theme/custom';
+import { Heading, logo } from 'my-theme:custom';
 ---
 ```
 
@@ -188,7 +188,7 @@ export default defineTheme({
   pages: {
     dir: 'pages',
     glob: [
-      '**.astro', 
+      '**.astro',
       '!**.{ts,js}'
     ]
   }

--- a/docs/src/content/docs/introduction/index.mdx
+++ b/docs/src/content/docs/introduction/index.mdx
@@ -48,11 +48,11 @@ Sint mollit adipisicing excepteur incididunt duis sunt enim qui proident nulla.
 
 ```tsx
 ---
-import { Layout } from 'my-theme/layouts';
-import { Card } from 'my-theme/components';
-import { logo } from 'my-theme/assets'
-import config from 'my-theme/config'
-import 'my-theme/css';
+import { Layout } from 'my-theme:layouts';
+import { Card } from 'my-theme:components';
+import { logo } from 'my-theme:assets'
+import config from 'my-theme:config'
+import 'my-theme:css';
 ---
 ```
 

--- a/docs/src/content/docs/reference/author.mdx
+++ b/docs/src/content/docs/reference/author.mdx
@@ -62,7 +62,7 @@ schema: z.object({
 
 ```ts
 ---
-import config from "my-theme/config"
+import config from "my-theme:config"
 
 console.log(config.title, config.description)
 ---
@@ -185,7 +185,7 @@ imports: {
 ```
 
 ```ts
-import { Hero, Card, Button } from "my-theme/components"
+import { Hero, Card, Button } from "my-theme:components"
 ```
 
 **`array`**: 
@@ -203,7 +203,7 @@ imports: {
 ```
 
 ```ts
-import "my-theme/css"
+import "my-theme:css"
 ```
 
 **`object`**: 
@@ -222,7 +222,7 @@ imports: {
 ```
 
 ```ts
-import Layout, { Head, Button } from "my-theme/components"
+import Layout, { Head, Button } from "my-theme:components"
 ```
 
 ### `log`
@@ -296,11 +296,11 @@ Use the generated virtual modules to author the theme
 ```tsx
 // package/src/pages/index.astro
 ---
-import { Layout } from 'my-theme/layouts';
-import { Card } from 'my-theme/components';
-import { logo } from 'my-theme/assets'
-import config from 'my-theme/config'
-import 'my-theme/css';
+import { Layout } from 'my-theme:layouts';
+import { Card } from 'my-theme:components';
+import { logo } from 'my-theme:assets'
+import config from 'my-theme:config'
+import 'my-theme:css';
 
 const {
   title,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -123,12 +123,12 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 					// Record of virtual imports and their content
 					const virtualImports: Record<string, string> = {
-						[`${themeName}/config`]: `export default ${JSON.stringify(userConfig)}`,
+						[`${themeName}:config`]: `export default ${JSON.stringify(userConfig)}`,
 					};
 
 					// Module type buffers
 					const moduleBuffers: Record<string, string> = {
-						[`${themeName}/config`]: `
+						[`${themeName}:config`]: `
 							const config: NonNullable<NonNullable<Parameters<typeof import("${themeEntrypoint}").default>[0]>["config"]>;
 							export default config;
 						`,
@@ -222,11 +222,11 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 						// Reserved module/import names
 						if (["config", "pages", "content", "db"].includes(name)) {
-							logger.warn(`Module name '${name}' is reserved for the built in virtual import '${themeName}/${name}'`);
+							logger.warn(`Module name '${name}' is reserved for the built in virtual import '${themeName}:${name}'`);
 							continue;
 						}
 
-						const moduleName = normalizePath(join(themeName, name));
+						const moduleName = normalizePath(join(themeName, name)).replace(/\//, ':');
 
 						// Turn a glob string into a module object
 						if (typeof option === "string") {
@@ -247,7 +247,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 						// Check if module exists and contains overrides
 						if (override) {
-							const altModuleName = moduleName.replace(/\//, ":");
+							const altModuleName = moduleName.replace(/:/, "::");
 							const moduleOverride = createVirtualModule(altModuleName, projectRoot, toModuleObject(override));
 							if (!isEmptyModuleObject(moduleOverride)) {
 								// Add virtual module to import buffer

--- a/package/tests/theme.test.js
+++ b/package/tests/theme.test.js
@@ -18,11 +18,11 @@ const packageJSON = JSON.parse(readFileSync(resolve(packageRoot, "package.json")
 const packageName = packageJSON.name;
 const astroIntegration = { name: "astro-integration" };
 const defaultModules = {
-	[`${packageName}/config`]: {},
-	[`${packageName}/css`]: ["css/styles.css"],
-	[`${packageName}/assets`]: ["assets/levi.png"],
-	[`${packageName}/layouts`]: ["layouts/Layout.astro"],
-	[`${packageName}/components`]: ["components/Heading.astro"],
+	[`${packageName}:config`]: {},
+	[`${packageName}:css`]: ["css/styles.css"],
+	[`${packageName}:assets`]: ["assets/levi.png"],
+	[`${packageName}:layouts`]: ["layouts/Layout.astro"],
+	[`${packageName}:components`]: ["components/Heading.astro"],
 };
 
 const defineTheme = (option) => {

--- a/package/tests/theme.test.js
+++ b/package/tests/theme.test.js
@@ -237,7 +237,7 @@ describe("defineTheme", () => {
 					if (!Array.isArray(moduleFiles)) continue;
 					const resolved = resolveId(moduleName);
 					const content = plugin.load(resolved);
-					const key = moduleName.split("/").pop();
+					const key = moduleName.split(":").pop();
 					for (const file of overrides[key]) {
 						const testImport = new RegExp(`import \"${normalizePath(resolve(projectRoot, file))}\";`, "g");
 						const testExport = new RegExp(`export {.*} from \"${normalizePath(resolve(projectRoot, file))}\";`, "g");

--- a/tests/themes/theme-playground/src/components/Heading.astro
+++ b/tests/themes/theme-playground/src/components/Heading.astro
@@ -1,5 +1,5 @@
 ---
-import config from "theme-playground/config";
+import config from "theme-playground:config";
 
 interface Props {
 	title?: string;

--- a/tests/themes/theme-playground/src/layouts/Layout.astro
+++ b/tests/themes/theme-playground/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import "theme-playground/css";
+import "theme-playground:css";
 ---
 
 <html lang="en">

--- a/tests/themes/theme-playground/src/pages/cats/[...cat].astro
+++ b/tests/themes/theme-playground/src/pages/cats/[...cat].astro
@@ -1,9 +1,9 @@
 ---
 import { Image } from "astro:assets";
-import { Layout } from "theme-playground/layouts";
+import { Layout } from "theme-playground:layouts";
 
 export async function getStaticPaths() {
-	const images = Object.entries(await import("theme-playground/assets"));
+	const images = Object.entries(await import("theme-playground:assets"));
 	return images.map(([name, image], i) => {
 		return {
 			params: {

--- a/tests/themes/theme-playground/src/pages/cats/index.astro
+++ b/tests/themes/theme-playground/src/pages/cats/index.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from "astro:assets";
-import { sit } from "theme-playground/assets";
-import { Layout } from "theme-playground/layouts";
+import { Layout } from "theme-playground:layouts";
+import { sit } from "theme-playground:assets";
 ---
 
 <Layout>

--- a/tests/themes/theme-playground/src/pages/index.astro
+++ b/tests/themes/theme-playground/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
-import { Heading } from "theme-playground/components";
-import config from "theme-playground/config";
-import { Layout } from "theme-playground/layouts";
+import { Heading } from "theme-playground:components";
+import config from "theme-playground:config";
+import { Layout } from "theme-playground:layouts";
 ---
 
 <Layout>

--- a/tests/themes/theme-ssg/src/components/Heading.astro
+++ b/tests/themes/theme-ssg/src/components/Heading.astro
@@ -1,5 +1,5 @@
 ---
-import config from "theme-ssg/config";
+import config from "theme-ssg:config";
 
 interface Props {
 	title?: string;

--- a/tests/themes/theme-ssg/src/layouts/Layout.astro
+++ b/tests/themes/theme-ssg/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import "theme-ssg/css";
+import "theme-ssg:css";
 ---
 
 <html lang="en">

--- a/tests/themes/theme-ssg/src/pages/config.json.ts
+++ b/tests/themes/theme-ssg/src/pages/config.json.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import config from "theme-ssg/config";
+import config from "theme-ssg:config";
 
 export const GET: APIRoute = async () => {
 	return new Response(JSON.stringify(config));

--- a/tests/themes/theme-ssg/src/pages/index.astro
+++ b/tests/themes/theme-ssg/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
-import { Heading } from "theme-ssg/components";
-import config from "theme-ssg/config";
-import { Layout } from "theme-ssg/layouts";
+import { Heading } from "theme-ssg:components";
+import config from "theme-ssg:config";
+import { Layout } from "theme-ssg:layouts";
 ---
 
 <Layout>


### PR DESCRIPTION
Goal is to resolve https://github.com/astrolicious/astro-theme-provider/issues/80 which allows for `export` statements in `package.json`.