### PR TITLE
Add a utility to get the final path of a page

### DIFF
--- a/.changeset/short-zoos-march.md
+++ b/.changeset/short-zoos-march.md
@@ -1,0 +1,15 @@
+---
+"astro-theme-provider": minor
+---
+
+Added a utility to query the final path of a page:
+
+```astro
+---
+import { pages } from 'my-theme:context'
+---
+
+{ pages.has('/blog') &&
+  <a href={pages.get('/blog')}>Blog</a>
+}
+```

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -338,23 +338,25 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 					};
 
 					// Initialize route injection
-					const { pages, injectPages } = addPageDir(pageDirOption);
+					const { pages: pagesInjected, injectPages } = addPageDir(pageDirOption);
+					const pagesResolved: Record<string, string | false> = Object.fromEntries(Object.keys(pagesInjected).map(p => [p, p]))
 
 					// Generate types for possibly injected routes
-					interfaceBuffers.ThemeRoutes += Object.entries(pages)
+					interfaceBuffers.ThemeRoutes += Object.entries(pagesInjected)
 						.map(([pattern, entrypoint]) => `\n"${pattern}": typeof import("${entrypoint}").default`)
 						.join("");
 
 					// Filter out routes the theme user toggled off
 					for (const oldPattern of Object.keys(userPages)) {
 						// Skip pages that are not defined by author
-						if (!pages?.[oldPattern!]) continue;
+						if (!pagesInjected?.[oldPattern!]) continue;
 
 						let newPattern = userPages[oldPattern as keyof typeof userPages];
 
 						// If user passes falsy value remove the route
 						if (!newPattern) {
-							delete pages[oldPattern];
+							pagesResolved[oldPattern] = false
+							delete pagesInjected[oldPattern];
 							continue;
 						}
 
@@ -368,14 +370,21 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 								);
 							}
 							// Add new pattern
-							pages[newPattern] = pages[oldPattern]!;
+							pagesInjected[newPattern] = pagesInjected[oldPattern]!;
+							pagesResolved[oldPattern] = newPattern
 							// Remove old pattern
-							delete pages[oldPattern];
+							delete pagesInjected[oldPattern];
 						}
 					}
 
+					// Virtual module for integration utilities
+					virtualImports[`${themeName}:context`] += `\nexport const pages = new Map(Object.entries(${JSON.stringify(
+						pagesResolved,
+					)}))`;
+					moduleBuffers[`${themeName}:context`] += `\nexport const pages: Map<${Object.keys(pagesResolved).map(p => `"${p}"`).join(' | ')}, tring | false>`;
+
 					// Generate types for injected routes
-					interfaceBuffers.ThemeRoutesResolved += Object.entries(pages)
+					interfaceBuffers.ThemeRoutesResolved += Object.entries(pagesInjected)
 						.map(([pattern, entrypoint]) => `\n"${pattern}": typeof import("${entrypoint}").default`)
 						.join("");
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -339,7 +339,9 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 					// Initialize route injection
 					const { pages: pagesInjected, injectPages } = addPageDir(pageDirOption);
-					const pagesResolved: Record<string, string | false> = Object.fromEntries(Object.keys(pagesInjected).map(p => [p, p]))
+					const pagesResolved: Record<string, string | false> = Object.fromEntries(
+						Object.keys(pagesInjected).map((p) => [p, p]),
+					);
 
 					// Generate types for possibly injected routes
 					interfaceBuffers.ThemeRoutes += Object.entries(pagesInjected)
@@ -355,7 +357,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 
 						// If user passes falsy value remove the route
 						if (!newPattern) {
-							pagesResolved[oldPattern] = false
+							pagesResolved[oldPattern] = false;
 							delete pagesInjected[oldPattern];
 							continue;
 						}
@@ -371,7 +373,7 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 							}
 							// Add new pattern
 							pagesInjected[newPattern] = pagesInjected[oldPattern]!;
-							pagesResolved[oldPattern] = newPattern
+							pagesResolved[oldPattern] = newPattern;
 							// Remove old pattern
 							delete pagesInjected[oldPattern];
 						}
@@ -381,7 +383,9 @@ export default function <ThemeName extends string, Schema extends z.ZodTypeAny>(
 					virtualImports[`${themeName}:context`] += `\nexport const pages = new Map(Object.entries(${JSON.stringify(
 						pagesResolved,
 					)}))`;
-					moduleBuffers[`${themeName}:context`] += `\nexport const pages: Map<${Object.keys(pagesResolved).map(p => `"${p}"`).join(' | ')}, tring | false>`;
+					moduleBuffers[`${themeName}:context`] += `\nexport const pages: Map<${Object.keys(pagesResolved)
+						.map((p) => `"${p}"`)
+						.join(" | ")}, tring | false>`;
 
 					// Generate types for injected routes
 					interfaceBuffers.ThemeRoutesResolved += Object.entries(pagesInjected)

--- a/tests/themes/theme-playground/src/pages/index.astro
+++ b/tests/themes/theme-playground/src/pages/index.astro
@@ -1,11 +1,9 @@
 ---
 import { Heading } from "theme-playground:components";
 import config from "theme-playground:config";
-import { integrations } from "theme-playground:context";
+import { integrations, pages } from "theme-playground:context";
 import { Layout } from "theme-playground:layouts";
-
-if (integrations.has("@astrojs/sitemap")) {
-}
+import type { cat } from "theme-ssg/assets";
 ---
 
 <Layout>
@@ -16,6 +14,15 @@ if (integrations.has("@astrojs/sitemap")) {
   <ul>
     <li><a href="/cats">Cats - Dynamic routing and images</a></li>
   </ul>
+	<h3>Pages</h3>
+	<table>
+		{Object.entries(Object.fromEntries(pages)).map(path => {
+			return <tr>
+				<td>{path[0]}</td>
+				<td>{path[1] || 'false'}</td>
+			</tr>
+		})}
+	<table/>
 	<h3>Integrations</h3>
 	<ul>
 		{Array.from(integrations).map(name => {


### PR DESCRIPTION
Added a utility to query the final path of a page:

```astro
---
import { pages } from 'my-theme:context'
---

{ pages.has('/blog') &&
  <a href={pages.get('/blog')}>Blog</a>
}
```