### PR TITLE
Migrate to native `injectTypes` function

### DIFF
--- a/.changeset/silly-olives-joke.md
+++ b/.changeset/silly-olives-joke.md
@@ -1,0 +1,5 @@
+---
+"astro-theme-provider": patch
+---
+
+Migrate away from the AIK utility `addDts` to the native utility `injectTypes`

--- a/package/tests/theme.test.js
+++ b/package/tests/theme.test.js
@@ -260,22 +260,6 @@ describe("defineTheme", () => {
 					}
 				}
 			});
-
-			it("should generate types", () => {
-				const theme = defineTheme({})();
-				const params = astroConfigSetupParamsStub();
-
-				theme.hooks["astro:config:setup"]?.(params);
-
-				assert.equal(
-					readFileSync(resolve(projectSrc, "env.d.ts"), "utf-8").includes(
-						`/// <reference types="../.astro/${packageName}.d.ts" />`,
-					),
-					true,
-				);
-
-				assert.equal(existsSync(resolve(projectRoot, `.astro/${packageName}.d.ts`)), true);
-			});
 		});
 	});
 });


### PR DESCRIPTION
Replace `addDts` utility from AIK with native `injectTypes` function