### PR TITLE
ignore `package.json` for Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,11 @@
 	"organizeImports": {
 		"enabled": true
 	},
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
 	"formatter": {
 		"lineWidth": 120
 	},
@@ -13,6 +18,6 @@
 		}
 	},
 	"files": {
-		"ignore": ["dist", ".astro"]
+		"ignore": ["package.json"]
 	}
 }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,30 +1,30 @@
 /* Dark mode colors. */
 :root {
-  --sl-color-accent-low: #072d00;
-  --sl-color-accent: #247f00;
-  --sl-color-accent-high: #aad7a0;
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #eeeeee;
-  --sl-color-gray-2: #c2c2c2;
-  --sl-color-gray-3: #8b8b8b;
-  --sl-color-gray-4: #585858;
-  --sl-color-gray-5: #383838;
-  --sl-color-gray-6: #272727;
-  --sl-color-black: #181818;
+	--sl-color-accent-low: #072d00;
+	--sl-color-accent: #247f00;
+	--sl-color-accent-high: #aad7a0;
+	--sl-color-white: #ffffff;
+	--sl-color-gray-1: #eeeeee;
+	--sl-color-gray-2: #c2c2c2;
+	--sl-color-gray-3: #8b8b8b;
+	--sl-color-gray-4: #585858;
+	--sl-color-gray-5: #383838;
+	--sl-color-gray-6: #272727;
+	--sl-color-black: #181818;
 }
 
 /* Light mode colors. */
-:root[data-theme='light'] {
-  --sl-color-accent-low: #c0e2b8;
-  --sl-color-accent: #258100;
-  --sl-color-accent-high: #0d3e00;
-  --sl-color-white: #181818;
-  --sl-color-gray-1: #272727;
-  --sl-color-gray-2: #383838;
-  --sl-color-gray-3: #585858;
-  --sl-color-gray-4: #8b8b8b;
-  --sl-color-gray-5: #c2c2c2;
-  --sl-color-gray-6: #eeeeee;
-  --sl-color-gray-7: #f6f6f6;
-  --sl-color-black: #ffffff;
+:root[data-theme="light"] {
+	--sl-color-accent-low: #c0e2b8;
+	--sl-color-accent: #258100;
+	--sl-color-accent-high: #0d3e00;
+	--sl-color-white: #181818;
+	--sl-color-gray-1: #272727;
+	--sl-color-gray-2: #383838;
+	--sl-color-gray-3: #585858;
+	--sl-color-gray-4: #8b8b8b;
+	--sl-color-gray-5: #c2c2c2;
+	--sl-color-gray-6: #eeeeee;
+	--sl-color-gray-7: #f6f6f6;
+	--sl-color-black: #ffffff;
 }

--- a/playground/src/custom.css
+++ b/playground/src/custom.css
@@ -1,3 +1,3 @@
 * {
-  color: red !important;
+	color: red !important;
 }

--- a/tests/themes/theme-playground/src/styles/global.css
+++ b/tests/themes/theme-playground/src/styles/global.css
@@ -1,52 +1,51 @@
 html,
 body {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  font-family: Arial, Helvetica, sans-serif;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	font-family: Arial, Helvetica, sans-serif;
 }
 
 body > a {
-  position: absolute;
-  top: 1rem;
-  left: 1rem;
+	position: absolute;
+	top: 1rem;
+	left: 1rem;
 }
 
 main {
-  height: 100%;
-  display: grid;
-  place-content: center;
-  text-align: center;
-  margin-top: -3rem;
+	height: 100%;
+	display: grid;
+	place-content: center;
+	text-align: center;
+	margin-top: -3rem;
 }
 
 img {
-  max-width: 250px;
-  height: auto;
+	max-width: 250px;
+	height: auto;
 }
 
 h1 {
-  font-size: 5rem;
+	font-size: 5rem;
 }
 
 h2 {
-  font-style: italic;
-  font-weight: normal;
-  font-size: 1.75rem;
+	font-style: italic;
+	font-weight: normal;
+	font-size: 1.75rem;
 }
 
 code {
-  background-color: rgba(0,0,0,0.15);
-  padding: 0.2rem;
-  font-size: 1.5rem;
+	background-color: rgba(0, 0, 0, 0.15);
+	padding: 0.2rem;
+	font-size: 1.5rem;
 }
 
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 li {
-
 }

--- a/tests/themes/theme-ssg/src/styles/global.css
+++ b/tests/themes/theme-ssg/src/styles/global.css
@@ -1,3 +1,3 @@
 body {
-  background-color: #00FF00;
+	background-color: #00ff00;
 }


### PR DESCRIPTION
when run `pnpm lint:fix`, the `package.json` are also formated,
It should not be processed by biome, because it will be modified by `pnpm install` or other commands

and I saw lots of errors not suppressed or resolved